### PR TITLE
Add movie duration info

### DIFF
--- a/cathode/src/main/java/net/simonvt/cathode/ui/movie/MovieFragment.java
+++ b/cathode/src/main/java/net/simonvt/cathode/ui/movie/MovieFragment.java
@@ -106,6 +106,7 @@ public class MovieFragment extends RefreshableAppBarFragment
 
   @BindView(R.id.year) TextView year;
   @BindView(R.id.certification) TextView certification;
+  @BindView(R.id.runtime) TextView runtime;
   //@BindView(R.id.poster) RemoteImageView poster;
   @BindView(R.id.overview) TextView overview;
 
@@ -371,6 +372,21 @@ public class MovieFragment extends RefreshableAppBarFragment
     }
     final int year = Cursors.getInt(cursor, MovieColumns.YEAR);
     final String certification = Cursors.getString(cursor, MovieColumns.CERTIFICATION);
+    final Integer runtimeInt = Cursors.getIntOrNull(cursor, MovieColumns.RUNTIME);
+
+    if (runtimeInt != null){
+      String runtimeString;
+      if (runtimeInt > 60){
+        runtimeString = String.format(getString(R.string.runtime_minutes_and_hours), runtimeInt / 60, runtimeInt % 60);
+      }else{
+        runtimeString = String.format(getString(R.string.runtime_minutes), runtimeInt);
+      }
+      runtime.setText(runtimeString);
+      runtime.setVisibility(View.VISIBLE);
+    }else{
+      runtime.setVisibility(View.GONE);
+    }
+
 
     final String backdropUri = ImageUri.create(ImageUri.ITEM_MOVIE, ImageType.BACKDROP, movieId);
     setBackdrop(backdropUri, true);

--- a/cathode/src/main/res/layout/fragment_movie_top.xml
+++ b/cathode/src/main/res/layout/fragment_movie_top.xml
@@ -44,6 +44,13 @@
         android:layout_height="wrap_content"
         android:textColor="?android:attr/textColorPrimary"
         tools:text="TV-MA"/>
+
+    <TextView
+        android:id="@+id/runtime"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="?android:attr/textColorPrimary"
+        tools:text="0min"/>
   </LinearLayout>
 
   <net.simonvt.cathode.common.widget.CircularProgressIndicator

--- a/cathode/src/main/res/values/strings.xml
+++ b/cathode/src/main/res/values/strings.xml
@@ -71,6 +71,9 @@
   <string name="related_rating">%1$s (%2$d votes)</string>
   <string name="related_rating_thousands">%1$s (%2$sk votes)</string>
 
+  <string name="runtime_minutes">%dmin</string>
+  <string name="runtime_minutes_and_hours">%1$dh %2$dmin</string>
+
   <string name="person_department_cast">Cast</string>
   <string name="person_department_production">Production</string>
   <string name="person_department_art">Art</string>


### PR DESCRIPTION
Added movie duration below movie year and certification. Check image to see how it looks:

![screenshot_20180826-135356](https://user-images.githubusercontent.com/5485164/44627956-99987100-a937-11e8-80c8-9d2ae5c26406.jpg)
